### PR TITLE
Reset EOF in the event of an error

### DIFF
--- a/src/couch_ngen_file.erl
+++ b/src/couch_ngen_file.erl
@@ -337,7 +337,8 @@ handle_call({append, Bin}, _From, St) ->
             },
             {reply, {error, incomplete_write}, NewSt, ?MONITOR_CHECK};
         Error ->
-            {reply, Error, St, ?MONITOR_CHECK}
+            {ok, Eof} = nifile:seek(St#st.fd, 0, seek_end),
+            {reply, Error, St#st{eof = Eof}, ?MONITOR_CHECK}
     end.
 
 


### PR DESCRIPTION
A fix for couch_ngen for the same bug in couch_file (COUCHDB-3274).